### PR TITLE
Update scraper to handle multiple URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
 ## Configuration
 
 - Longueur du texte : <https://github.com/constructions-incongrues/lesbarques/settings/variables/actions#repository-variables>
+
+## Scraping Multiple URLs
+
+The scraper now supports scraping content from multiple URLs. You can provide a comma-separated list of URLs to the `scripts/scrape.py` script.


### PR DESCRIPTION
Update `scripts/scrape.py` to support scraping multiple URLs.

* Modify the `url` argument to `urls` and split it into a list of URLs.
* Iterate over each URL, scrape content, and append results to the final output.
* Initialize final results lists for texts, images, and audios.
* Update the output directory argument to `docs`.

Update `README.md` to mention the capability to scrape multiple URLs.

* Add a new section explaining how to provide a comma-separated list of URLs to the `scripts/scrape.py` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/constructions-incongrues/lesbarques/pull/11?shareId=e752b353-ce4b-4a5d-8e11-573d8ea75a51).